### PR TITLE
User flow

### DIFF
--- a/client/background/index.js
+++ b/client/background/index.js
@@ -215,6 +215,13 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 //NOTFICATION STUFF IS BELOW
 
+/* //User will be annoyed with notifications way too often for demo purposes
+chrome.alarms.create('alarm', { periodInMinutes: 0.2 })
+
+chrome.alarms.onAlarm.addListener(function (alarm) {
+  initNotification()
+}) */
+
 // I needed to break notification-making into two functions because querying tabs is asynchronus
 function initNotification() {
   //If there's an active page, get the page title and init a notification

--- a/client/background/index.js
+++ b/client/background/index.js
@@ -13,6 +13,7 @@ import {
   classifyDocument
 } from './bayesClassifier'
 import {dateConverter, timeInSecond} from './utils'
+import {initLearnMoreNotification} from './newUserTest'
 import db from '../db'
 
 var currentWindow
@@ -26,7 +27,13 @@ chrome.windows.onFocusChanged.addListener(function(windowInfo) {
     chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => {
       if (tabs[0]) {
         var url = new URL(tabs[0].url)
-
+        //test for whether a model exists
+        //TODO: change number to "1" before deploying
+        db.bayesModel.get(100000, m => {
+          if (!m) {
+            initLearnMoreNotification(tabs[0])
+          }
+        })
         // Update time end when focus out of the tab
         db.history
           .toArray()

--- a/client/background/index.js
+++ b/client/background/index.js
@@ -69,7 +69,7 @@ chrome.windows.onFocusChanged.addListener(function(windowInfo) {
 chrome.tabs.onActivated.addListener(function(activeInfo) {
   //get detail information of activated tab
   chrome.tabs.get(activeInfo.tabId, async function(tab) {
-    //this is a silly function that changes the badge text
+    initNotification()
     const pageClassification = await classifyDocument(tab.title)
     const probabilities = await getClassifications(tab.title)
     const certainty =
@@ -208,12 +208,6 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 //NOTFICATION STUFF IS BELOW
 
-//User will be annoyed with notifications way too often for demo purposes
-chrome.alarms.create('alarm', {periodInMinutes: 0.2})
-
-chrome.alarms.onAlarm.addListener(function(alarm) {
-  initNotification()
-})
 // I needed to break notification-making into two functions because querying tabs is asynchronus
 function initNotification() {
   //If there's an active page, get the page title and init a notification

--- a/client/background/newUserTest.js
+++ b/client/background/newUserTest.js
@@ -1,0 +1,22 @@
+//Prompts user to learn more about app if there's no model
+function makeLearnMoreNotification() {
+  chrome.notifications.create('dashboard.html#about', {
+    type: 'basic',
+    title: 'Thanks for downloading Wirehead!',
+    iconUrl: 'gray.png',
+    message:
+      "Click here to more about our app! (You'll keep getting these notifications until you give our AI some training data to work with!)",
+    requireInteraction: true
+  })
+
+  chrome.notifications.onClicked.addListener(function handleClick(
+    notificationId
+  ) {
+    chrome.tabs.create({url: notificationId})
+    chrome.notifications.onButtonClicked.removeListener(handleClick)
+  })
+}
+
+export function initLearnMoreNotification(tab) {
+  if (tab) makeLearnMoreNotification()
+}

--- a/client/db.js
+++ b/client/db.js
@@ -10,6 +10,37 @@ db.version(5).stores({
   bayesModel: '++id, model'
 })
 
+function makeNotification() {
+  chrome.notifications.create('dashboard.html#about', {
+    type: 'basic',
+    title: 'Thanks for downloading Wirehead!',
+    iconUrl: 'gray.png',
+    message: 'Learn more about our app!',
+    requireInteraction: true
+  })
+
+  chrome.notifications.onClicked.addListener(function handleClick(
+    notificationId
+  ) {
+    chrome.tabs.create({url: notificationId})
+    chrome.notifications.onButtonClicked.removeListener(handleClick)
+  })
+}
+function initNotification() {
+  //If there's an active page, get the page title and init a notification
+  chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => {
+    if (tabs[0]) {
+      makeNotification(tabs[0].title)
+    }
+  })
+}
+
+db.bayesModel.get(100000, m => {
+  if (!m) {
+    initNotification()
+  }
+})
+
 db.history.get(1, s => {
   if (!s) {
     db.history.bulkAdd(history)

--- a/client/db.js
+++ b/client/db.js
@@ -10,37 +10,7 @@ db.version(5).stores({
   bayesModel: '++id, model'
 })
 
-function makeNotification() {
-  chrome.notifications.create('dashboard.html#about', {
-    type: 'basic',
-    title: 'Thanks for downloading Wirehead!',
-    iconUrl: 'gray.png',
-    message: 'Learn more about our app!',
-    requireInteraction: true
-  })
-
-  chrome.notifications.onClicked.addListener(function handleClick(
-    notificationId
-  ) {
-    chrome.tabs.create({url: notificationId})
-    chrome.notifications.onButtonClicked.removeListener(handleClick)
-  })
-}
-function initNotification() {
-  //If there's an active page, get the page title and init a notification
-  chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => {
-    if (tabs[0]) {
-      makeNotification(tabs[0].title)
-    }
-  })
-}
-
-db.bayesModel.get(100000, m => {
-  if (!m) {
-    initNotification()
-  }
-})
-
+//TODO: remove seeding db before deploying
 db.history.get(1, s => {
   if (!s) {
     db.history.bulkAdd(history)
@@ -48,6 +18,7 @@ db.history.get(1, s => {
   }
 })
 
+//functions for making querying our db easier
 Dexie.prototype.bla = () => 'aaaaaaaaaaaaaaaaaaaa'
 
 console.log(db.bla())


### PR DESCRIPTION
This adds a prompt when you change pages that directs you to the "about" page. It will fire every time you visit a new site! But once we build the about site we can make a small change to the code and then it will only fire if you don't have a model saved in the db.

Also I changed the training notification to only fire when I visit a new site. This seemed less annoying to me but the alarm code is still there, just commented out.
